### PR TITLE
Markdown formatting for code blocks

### DIFF
--- a/5.2curlcommands.md
+++ b/5.2curlcommands.md
@@ -1,425 +1,463 @@
-#Example Curl Commands to register previewers for Dataverse, version 5.2+
+# Example Curl Commands to register previewers for Dataverse, version 5.2+
 
 You should be able to cut/paste any/all of the commands below to run on your Dataverse machine:
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"Read Text\",
->  \"description\":\"Read the text file.\",
->  \"toolName\":\"textPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"text/plain\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Read Text",
+  "description":"Read the text file.",
+  "toolName":"textPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/plain"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"View Html\",
->  \"description\":\"View the html file.\",
->  \"toolName\":\"htmlPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/HtmlPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"text/html"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Html",
+  "description":"View the html file.",
+  "toolName":"htmlPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/HtmlPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/html"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"Play Audio\",
->  \"description\":\"Listen to an audio file.\",
->  \"toolName\":\"audioPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"audio/mp3\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Audio",
+  "description":"Listen to an audio file.",
+  "toolName":"audioPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"audio/mp3"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"Play Audio\",
->  \"description\":\"Listen to an audio file.\",
->  \"toolName\":\"audioPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"audio/mpeg\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Audio",
+  "description":"Listen to an audio file.",
+  "toolName":"audioPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"audio/mpeg"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"Play Audio\",
->  \"description\":\"Listen to an audio file.\",
->  \"toolName\":\"audioPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"audio/wav\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Audio",
+  "description":"Listen to an audio file.",
+  "toolName":"audioPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"audio/wav"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"Play Audio\",
->  \"description\":\"Listen to an audio file.\",
->  \"toolName\":\"audioPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"audio/ogg\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Audio",
+  "description":"Listen to an audio file.",
+  "toolName":"audioPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"audio/ogg"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"View Image\",
->  \"description\":\"Preview an image file.\",
->  \"toolName\":\"imagePreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"image/gif\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Image",
+  "description":"Preview an image file.",
+  "toolName":"imagePreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"image/gif"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"View Image\",
->  \"description\":\"Preview an image file.\",
->  \"toolName\":\"imagePreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"image/jpeg\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Image",
+  "description":"Preview an image file.",
+  "toolName":"imagePreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"image/jpeg"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"View Image\",
->  \"description\":\"Preview an image file.\",
->  \"toolName\":\"imagePreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"image/png\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Image",
+  "description":"Preview an image file.",
+  "toolName":"imagePreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"image/png"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"Read Document\",
->  \"description\":\"Read a pdf document.\",
->  \"toolName\":\"pdfPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/PDFPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"application/pdf\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Read Document",
+  "description":"Read a pdf document.",
+  "toolName":"pdfPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/PDFPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"application/pdf"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"Play Video\",
->  \"description\":\"Watch a video file.\",
->  \"toolName\":\"videoPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"video/mp4\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Video",
+  "description":"Watch a video file.",
+  "toolName":"videoPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"video/mp4"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"Play Video\",
->  \"description\":\"Watch a video file.\",
->  \"toolName\":\"videoPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"video/ogg\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Video",
+  "description":"Watch a video file.",
+  "toolName":"videoPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"video/ogg"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"Play Video\",
->  \"description\":\"Watch a video file.\",
->  \"toolName\":\"videoPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"video/quicktime\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Video",
+  "description":"Watch a video file.",
+  "toolName":"videoPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"video/quicktime"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"View Data\",
->  \"description\":\"View the spreadsheet data.\",
->  \"toolName\":\"spreadsheetPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"text/comma-separated-values\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Data",
+  "description":"View the spreadsheet data.",
+  "toolName":"spreadsheetPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/comma-separated-values"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"View Data\",
->  \"description\":\"View the spreadsheet data.\",
->  \"toolName\":\"spreadsheetPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"text/tab-separated-values\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Data",
+  "description":"View the spreadsheet data.",
+  "toolName":"spreadsheetPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/tab-separated-values"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"View Data\",
->  \"description\":\"View the spreadsheet data.\",
->  \"toolName\":\"spreadsheetPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"text/csv\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Data",
+  "description":"View the spreadsheet data.",
+  "toolName":"spreadsheetPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/csv"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"View Data\",
->  \"description\":\"View the spreadsheet data.\",
->  \"toolName\":\"spreadsheetPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"text/tsv\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Data",
+  "description":"View the spreadsheet data.",
+  "toolName":"spreadsheetPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/tsv"
+}'
+```
 
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Stata File",
+  "description":"View the Stata file as text.",
+  "toolName":"stataPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"application/x-stata-syntax"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"View Stata File\",
->  \"description\":\"View the Stata file as text.\",
->  \"toolName\":\"stataPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"application/x-stata-syntax\"
->}'
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View R file",
+  "description":"View the R file as text.",
+  "toolName":"rPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"type/x-r-syntax"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"View R file\",
->  \"description\":\"View the R file as text.\",
->  \"toolName\":\"rPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"type/x-r-syntax\"
->}'
-
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->'{
->  \"displayName\":\"View Annotations\",
->  \"description\":\"View the annotation entries in a file.\",
->  \"toolName\":\"annotationPreviewer\",
->  \"scope\":\"file\",
->  \"types\":[\"preview\"],
->  \"toolUrl\":\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/HypothesisPreview.html",
->  \"toolParameters\": {
->      \"queryParameters\":[
->        {\"fileid\":\"{fileId}\"},
->        {\"siteUrl\":\"{siteUrl}\"},
->        {\"key\":\"{apiToken}\"},
->        {\"datasetid\":\"{datasetId}\"},
->        {\"datasetversion\":\"{datasetVersion}\"},
->        {\"locale\":\"{localeCode}\"}
->      ]
->    },
->  \"contentType\":\"application/x-json-hypothesis\"
->}'
-
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Annotations",
+  "description":"View the annotation entries in a file.",
+  "toolName":"annotationPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/HypothesisPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"application/x-json-hypothesis"
+}'
+```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Dataverse Previewers
+
 A collection of data file previewers that conform to the [Dataverse](https://dataverse.org) external tools interface, originally developed by the [Qualitative Data Repository](https://qdr.syr.edu). Earlier versions of Dataverse (v4.11+) make previewers available through the external tools button on Dataset pages (left). Newer versions (v4.18+) also use previewers for embedded display on Datafile pages (right). Even more recent versions (5.2+) can distinguish 'preview' and 'explore' tools and display them in different ways/separate places.
 
 <img align="right" width="30%" src="https://github.com/GlobalDataverseCommunityConsortium/dataverse-previewers/blob/master/examples/previewInPage.PNG?raw=true">
 <img width="65%" src="https://github.com/GlobalDataverseCommunityConsortium/dataverse-previewers/blob/master/examples/datasetdisplay.png?raw=true">
 
-
 ## Installation
+
 These previewers can be run without downloading them by simply running the curl command(s) below to register then with your local dataverse instance. (You can also create local copies and register those).
 
 For updates such as enabling Internationalization, which change the parameters you need to register with (Internationalization requires that Dataverse send the localeCode to the previewers), you'll need to delete the registrations for existing previewers (using the Dataverse externalTools API) and re-register them again using the updated curl commands below.  
@@ -14,16 +15,18 @@ There is one command per mimetype you wish to preview (i.e. multiple commands to
 
 Note that Dataverse installations configured to redirect to S3 storage for file downloads will need to enable CORS at the storage layer as well as the application layer (the latter is enabled by default). (See, for example, [Amazon's CORS configuration guidance](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-cors-configuration.html)).
 
-Also note that using the commands below means that your installation will automatically start using updated versions of the previewers when the master branch of this repository is updated. We intend to announce upcoming changes on the dataverse-community@google-groups.com mailing list, but if you do not want this behavior, you can download the previewers and host them on your own server, adjusting the curl commands below to reference your local copies. 
+Also note that using the commands below means that your installation will automatically start using updated versions of the previewers when the master branch of this repository is updated. We intend to announce upcoming changes on the dataverse-community@google-groups.com mailing list, but if you do not want this behavior, you can download the previewers and host them on your own server, adjusting the curl commands below to reference your local copies.
 
 ## How do they work?
-The tools here are lightweight wrappers around standard HTML5 functionality (e.g. audio, video), or third-party libraries (pdf, spreadsheets) or some combination (e.g. standard image displays with a third-party library to allow zooming, simple text/html displays with third-party libraries used to sanitize content to avoid security issues). 
 
-## Customizations: 
+The tools here are lightweight wrappers around standard HTML5 functionality (e.g. audio, video), or third-party libraries (pdf, spreadsheets) or some combination (e.g. standard image displays with a third-party library to allow zooming, simple text/html displays with third-party libraries used to sanitize content to avoid security issues).
+
+## Customizations
+
 The previewers will use your favicon if it exists at the default Dataverse location: ```<your site URL>/javax.faces.resource/images/favicondataverse.png.xhtml```
 They will also place your logo in the upper left corner (240px wide x 140px high recommended) if you add one at ```<your site URL>/logos/preview_logo.png``` (which, by default, corresponds to a file of that name in your payara (or glassfish) ./docroot/logos directory (e.g. /usr/local/payara5/glassfish/domains/domain1/docroot/logos)). By default, a blank white image is shown.
 
-## Known Limitations:
+## Known Limitations
 
 To preview restricted content, a user must have permission to view the relevant dataset version and download the relevant file and must have created an API Token for themselves in Dataverse. (Viewing public/published content does not require an API Token.) Note that API Tokens should be treated like passwords - if you use previewers on public computers, you may want to 'Recreate' your API Token afterward (to invalidate the previous one). Also note that API Tokens expire - you may need to 'Recreate' one if you have not used it in a while. (Note that later versions of Dataverse change API token management and should create/recreate API tokens as needed.)
 
@@ -34,7 +37,8 @@ Video seeking does not work on some browsers and some Dataverse instances due to
 The image previewer only works with image/tiff files on some browsers (as of ~Jan 2020), so the registration for that mimetype has been removed from the list below.
 
 ## Acknowledgments
-The original tools were developed through the [Qualitative Data Repository](https://qdr.syr.edu) but are being offered to the Dataverse community at large. 
+
+The original tools were developed through the [Qualitative Data Repository](https://qdr.syr.edu) but are being offered to the Dataverse community at large.
 
 The Spreadsheet Previewer was contributed by [anncie-pcss](https://github.com/anncie-pcss).
 
@@ -54,10 +58,7 @@ Contributors are expected to keep the master branch in a 'production-ready' stat
 
 By committing code to the repository, Contributors are agreeing to make it available under the [MIT Open Source license](https://globaldataversecommunityconsortium.github.io/dataverse-previewers/LICENSE).
 
-## Curl commands to configure these tools with your Dataverse instance:
+## Curl commands to configure these tools with your Dataverse instance
 
-[Dataverse <= v5.1](pre5.2curlcommands.md)
-
-[Dataverse 5.2+](5.2curlcommands.md)
-
-
+- [Dataverse <= v5.1](pre5.2curlcommands.md)
+- [Dataverse 5.2+](5.2curlcommands.md)

--- a/pre5.2curlcommands.md
+++ b/pre5.2curlcommands.md
@@ -1,425 +1,463 @@
-#Example Curl Commands to register previewers for Dataverse, version <= 5.1
+# Example Curl Commands to register previewers for Dataverse, version <= 5.1
 
 You should be able to cut/paste any/all of the commands below to run on your Dataverse machine:
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"Read Text\\",
->  \\"description\\":\\"Read the text file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"text/plain\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Read Text",
+  "description":"Read the text file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/plain"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"View Html\\",
->  \\"description\\":\\"View the html file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/HtmlPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"text/html\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Html",
+  "description":"View the html file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/HtmlPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/html"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"Play Audio\\",
->  \\"description\\":\\"Listen to an audio file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"audio/mp3\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Audio",
+  "description":"Listen to an audio file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"audio/mp3"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"Play Audio\\",
->  \\"description\\":\\"Listen to an audio file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"audio/mpeg\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Audio",
+  "description":"Listen to an audio file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"audio/mpeg"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"Play Audio\\",
->  \\"description\\":\\"Listen to an audio file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"audio/wav\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Audio",
+  "description":"Listen to an audio file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"audio/wav"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"Play Audio\\",
->  \\"description\\":\\"Listen to an audio file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"audio/ogg\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Audio",
+  "description":"Listen to an audio file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/AudioPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"audio/ogg"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"View Image\\",
->  \\"description\\":\\"Preview an image file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"image/gif\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Image",
+  "description":"Preview an image file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"image/gif"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"View Image\\",
->  \\"description\\":\\"Preview an image file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"image/jpeg\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Image",
+  "description":"Preview an image file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"image/jpeg"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"View Image\\",
->  \\"description\\":\\"Preview an image file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"image/png\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Image",
+  "description":"Preview an image file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/ImagePreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"image/png"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"Read Document\\",
->  \\"description\\":\\"Read a pdf document.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/PDFPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"application/pdf\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Read Document",
+  "description":"Read a pdf document.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/PDFPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"application/pdf"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"Play Video\\",
->  \\"description\\":\\"Watch a video file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"video/mp4\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Video",
+  "description":"Watch a video file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"video/mp4"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"Play Video\\",
->  \\"description\\":\\"Watch a video file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"video/ogg\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Video",
+  "description":"Watch a video file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"video/ogg"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"Play Video\\",
->  \\"description\\":\\"Watch a video file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"video/quicktime\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"Play Video",
+  "description":"Watch a video file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/VideoPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"video/quicktime"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"View Data\\",
->  \\"description\\":\\"View the spreadsheet data.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"text/comma-separated-values\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Data",
+  "description":"View the spreadsheet data.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/comma-separated-values"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"View Data\\",
->  \\"description\\":\\"View the spreadsheet data.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"text/tab-separated-values\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Data",
+  "description":"View the spreadsheet data.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/tab-separated-values"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"View Data\\",
->  \\"description\\":\\"View the spreadsheet data.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"text/csv\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Data",
+  "description":"View the spreadsheet data.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/csv"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"View Data\\",
->  \\"description\\":\\"View the spreadsheet data.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"text/tsv\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Data",
+  "description":"View the spreadsheet data.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/SpreadsheetPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"text/tsv"
+}'
+```
 
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Stata File",
+  "description":"View the Stata file as text.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"application/x-stata-syntax"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"View Stata File\\",
->  \\"description\\":\\"View the Stata file as text.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"application/x-stata-syntax\\"
->}"
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View R file",
+  "description":"View the R file as text.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"type/x-r-syntax"
+}'
+```
 
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"View R file\\",
->  \\"description\\":\\"View the R file as text.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/TextPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"type/x-r-syntax\\"
->}"
-
->curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \\
->"{
->  \\"displayName\\":\\"View Annotations\\",
->  \\"description\\":\\"View the annotation entries in a file.\\",
->  \\"scope\\":\\"file\\",
->  \\"type\\":\\"explore\\",
->  \\"hasPreviewMode\\":\\"true\\",
->  \\"toolUrl\\":\\"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/HypothesisPreview.html\",
->  \\"toolParameters\\": {
->      \\"queryParameters\\":[
->        {\\"fileid\\":\\"{fileId}\\"},
->        {\\"siteUrl\\":\\"{siteUrl}\\"},
->        {\\"key\\":\\"{apiToken}\\"},
->        {\\"datasetid\\":\\"{datasetId}\\"},
->        {\\"datasetversion\\":\\"{datasetVersion}\\"},
->        {\\"locale\\":\\"{localeCode}\\"}
->      ]
->    },
->  \\"contentType\\":\\"application/x-json-hypothesis\\"
->}"
-
+```bash
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \ 
+'{
+  "displayName":"View Annotations",
+  "description":"View the annotation entries in a file.",
+  "scope":"file",
+  "type":"explore",
+  "hasPreviewMode":"true",
+  "toolUrl":"https://globaldataversecommunityconsortium.github.io/dataverse-previewers/previewers/HypothesisPreview.html\",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
+  "contentType":"application/x-json-hypothesis"
+}'
+```


### PR DESCRIPTION
This PR modifies the CURL commands to use code block markdown formatting. This should hopefully make things easier to copy/paste (particularly from the raw md files) and will improve readability in GitHub. 

See [example of rendered code blocks](https://github.com/kaitlinnewson/dataverse-previewers/blob/readme-format/5.2curlcommands.md).